### PR TITLE
Add encoder property with encode method

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ ctgan.fit(real_data, discrete_columns)
 
 # Create synthetic data
 synthetic_data = ctgan.sample(1000)
+
+# Encode real data into the latent space
+mu, logvar, std = ctgan.encode(real_data.head())
 ```
 
 *For more information about the dataset see:

--- a/ctgan/synthesizers/tvae.py
+++ b/ctgan/synthesizers/tvae.py
@@ -136,6 +136,7 @@ class TVAE(BaseSynthesizer):
             device = 'cuda'
 
         self._device = torch.device(device)
+        self.encoder = None
 
     @random_state
     def fit(self, train_data, discrete_columns=()):
@@ -157,10 +158,11 @@ class TVAE(BaseSynthesizer):
         loader = DataLoader(dataset, batch_size=self.batch_size, shuffle=True, drop_last=False)
 
         data_dim = self.transformer.output_dimensions
-        encoder = Encoder(data_dim, self.compress_dims, self.embedding_dim).to(self._device)
+        self.encoder = Encoder(data_dim, self.compress_dims, self.embedding_dim).to(self._device)
         self.decoder = Decoder(self.embedding_dim, self.decompress_dims, data_dim).to(self._device)
         optimizerAE = Adam(
-            list(encoder.parameters()) + list(self.decoder.parameters()), weight_decay=self.l2scale
+            list(self.encoder.parameters()) + list(self.decoder.parameters()),
+            weight_decay=self.l2scale,
         )
 
         self.loss_values = pd.DataFrame(columns=['Epoch', 'Batch', 'Loss'])
@@ -175,7 +177,7 @@ class TVAE(BaseSynthesizer):
             for id_, data in enumerate(loader):
                 optimizerAE.zero_grad()
                 real = data[0].to(self._device)
-                mu, std, logvar = encoder(real)
+                mu, std, logvar = self.encoder(real)
                 eps = torch.randn_like(std)
                 emb = eps * std + mu
                 rec, sigmas = self.decoder(emb)
@@ -240,7 +242,34 @@ class TVAE(BaseSynthesizer):
         data = data[:samples]
         return self.transformer.inverse_transform(data, sigmas.detach().cpu().numpy())
 
+    def encode(self, data):
+        """Encode ``data`` into the latent space using the trained encoder.
+
+        The input data is first transformed using ``self.transformer`` and then
+        passed through ``self.encoder``.
+
+        Args:
+            data (numpy.ndarray or pandas.DataFrame):
+                Data to encode.
+
+        Returns:
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+                The ``mu``, ``logvar`` and ``std`` tensors produced by the encoder.
+        """
+        if self.encoder is None:
+            raise ValueError('The model has not been fitted yet.')
+
+        self.encoder.eval()
+        data = self.transformer.transform(data)
+        tensor = torch.from_numpy(data.astype('float32')).to(self._device)
+        with torch.no_grad():
+            mu, std, logvar = self.encoder(tensor)
+        return mu, logvar, std
+
     def set_device(self, device):
         """Set the `device` to be used ('GPU' or 'CPU)."""
         self._device = device
-        self.decoder.to(self._device)
+        if hasattr(self, 'decoder') and self.decoder is not None:
+            self.decoder.to(self._device)
+        if hasattr(self, 'encoder') and self.encoder is not None:
+            self.encoder.to(self._device)

--- a/tests/unit/synthesizer/test_tvae.py
+++ b/tests/unit/synthesizer/test_tvae.py
@@ -42,3 +42,21 @@ class TestTVAE:
         assert iterator_mock.set_description.call_args_list[0] == call('Loss: 0.000')
         assert iterator_mock.set_description.call_args_list[1] == call('Loss: 1.235')
         assert iterator_mock.set_description.call_count == 2
+
+    def test_encode_shapes(self):
+        """``encode`` should return tensors with the expected shapes."""
+        data = pd.DataFrame({'a': range(6), 'b': range(6, 12)})
+        synth = TVAE(
+            embedding_dim=5,
+            compress_dims=(10,),
+            decompress_dims=(10,),
+            epochs=1,
+            batch_size=2,
+        )
+
+        synth.fit(data)
+        mu, logvar, std = synth.encode(data)
+
+        assert mu.shape == (len(data), synth.embedding_dim)
+        assert logvar.shape == (len(data), synth.embedding_dim)
+        assert std.shape == (len(data), synth.embedding_dim)


### PR DESCRIPTION
## Summary
- keep the TVAE encoder as an attribute
- expose new `encode` API
- ensure device moves encoder too
- document `encode` in README
- test encoder output shapes

## Testing
- `ruff check ctgan/synthesizers/tvae.py`
- `ruff check tests/unit/synthesizer/test_tvae.py`
- `ruff check .`
- `pytest -q tests/unit/synthesizer/test_tvae.py::TestTVAE.test_encode_shapes` *(fails: found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_686261f5658483329002d838f74c4d60